### PR TITLE
Add settings file to fix comment keyboard shortcut and auto-indents

### DIFF
--- a/settings/language-fea.cson
+++ b/settings/language-fea.cson
@@ -1,0 +1,4 @@
+'.source.AFDKO':
+  'editor':
+    'commentStart': '# '
+    'increaseIndentPattern': '(?x)^(\\s*(feature|lookup|anon(?:ymous)?|table)).*$'


### PR DESCRIPTION
Adds a new settings file to the grammar, which fixes the insert-comment keyboard shortcut to insert `#` and adds some auto-indent settings for `feature`, `table`, `anon`, and `lookup`
